### PR TITLE
renderer: allow a null value in renderer_scissor

### DIFF
--- a/src/render/renderer.zig
+++ b/src/render/renderer.zig
@@ -40,7 +40,7 @@ pub const Renderer = extern struct {
         return wlr_resource_get_buffer_size(resource, renderer, width, height);
     }
 
-    extern fn wlr_renderer_scissor(renderer: *Renderer, box: *wlr.Box) void;
+    extern fn wlr_renderer_scissor(renderer: *Renderer, box: ?*wlr.Box) void;
     pub const scissor = wlr_renderer_scissor;
 
     extern fn wlr_renderer_get_shm_texture_formats(renderer: *Renderer, len: *usize) [*]const u32;


### PR DESCRIPTION
See: https://github.com/swaywm/wlroots/blob/84dea55b20b60c229a5e31ccd37b58c96cba611a/include/wlr/render/wlr_renderer.h#L43