### PR TITLE
text_input_v3: add const in wlroots.zig

### DIFF
--- a/src/types/text_input_v3.zig
+++ b/src/types/text_input_v3.zig
@@ -3,7 +3,7 @@ const wlr = @import("../wlroots.zig");
 const wayland = @import("wayland");
 const wl = wayland.server.wl;
 
-pub const TextInputV3Manager = extern struct {
+pub const TextInputManagerV3 = extern struct {
     global: *wl.Global,
     text_inputs: wl.list.Head(TextInputV3, "link"),
 
@@ -11,11 +11,11 @@ pub const TextInputV3Manager = extern struct {
 
     events: extern struct {
         text_input: wl.Signal(*wlr.TextInputV3),
-        destroy: wl.Signal(*wlr.TextInputV3Manager),
+        destroy: wl.Signal(*wlr.TextInputManagerV3),
     },
 
-    extern fn wlr_text_input_manager_v3_create(server: *wl.Server) ?*wlr.TextInputV3Manager;
-    pub fn create(server: *wl.Server) !*wlr.TextInputV3Manager {
+    extern fn wlr_text_input_manager_v3_create(server: *wl.Server) ?*wlr.TextInputManagerV3;
+    pub fn create(server: *wl.Server) !*wlr.TextInputManagerV3 {
         return wlr_text_input_manager_v3_create(server) orelse error.OutOfMemory;
     }
 };

--- a/src/wlroots.zig
+++ b/src/wlroots.zig
@@ -43,6 +43,9 @@ pub const TouchPoint = @import("types/seat.zig").TouchPoint;
 
 pub const InputDevice = @import("types/input_device.zig").InputDevice;
 
+pub const TextInputV3 = @import("types/text_input_v3.zig").TextInputV3;
+pub const TextInputManagerV3 = @import("types/text_input_v3.zig").TextInputManagerV3;
+
 pub const Keyboard = @import("types/keyboard.zig").Keyboard;
 pub const KeyboardGroup = @import("types/keyboard_group.zig").KeyboardGroup;
 


### PR DESCRIPTION
fix a typo in the filename
rename TextInputV3Manager -> TextInputManagerV3