### PR TITLE
input_method: Wrap sendKey() to take an u32

### DIFF
--- a/src/types/input_method_v2.zig
+++ b/src/types/input_method_v2.zig
@@ -52,7 +52,9 @@ pub const InputMethodV2 = extern struct {
         },
 
         extern fn wlr_input_method_keyboard_grab_v2_send_key(keyboard_grab: *wlr.InputMethodV2.KeyboardGrab, time: u32, key: u32, state: u32) void;
-        pub const sendKey = wlr_input_method_keyboard_grab_v2_send_key;
+        pub fn sendKey(keyboard_grab: *wlr.InputMethodV2.KeyboardGrab, time: u32, key: u32, state: wl.Keyboard.KeyState) void {
+            wlr_input_method_keyboard_grab_v2_send_key(keyboard_grab, time, key, @intCast(u32, @enumToInt(state)));
+        }
 
         extern fn wlr_input_method_keyboard_grab_v2_send_modifiers(keyboard_grab: *wlr.InputMethodV2.KeyboardGrab, modifiers: *wlr.Keyboard.Modifiers) void;
         pub const sendModifiers = wlr_input_method_keyboard_grab_v2_send_modifiers;


### PR DESCRIPTION
Instead of an enum of Key.State, exactly like in `keyboardNotifyKey()` in `seat.zig`