### PR TITLE
ci: fix xbps invocation

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       - name: install deps
         run: |
-          xbps-install -S
-          xbps-install -uy xbps
+          xbps-install -Sy xbps
+          xbps-install -uy
           # wlroots dependencies as well as we build from source
-          xbps-install -uy MesaLib-devel libseat-devel eudev-libudev-devel libdrm-devel \
+          xbps-install -y MesaLib-devel libseat-devel eudev-libudev-devel libdrm-devel \
             libinput-devel libxkbcommon-devel pixman-devel wayland-devel wayland-protocols \
             xcb-util-errors-devel xcb-util-wm-devel xcb-util-renderutil-devel libxcb-devel \
             xcb-util-cursor-devel xcb-util-devel xcb-util-image-devel xcb-util-keysyms-devel \
@@ -53,10 +53,10 @@ jobs:
     steps:
       - name: install deps
         run: |
-          xbps-install -S
-          xbps-install -uy xbps
+          xbps-install -Sy xbps
+          xbps-install -uy
           # wlroots dependencies as well as we build from source
-          xbps-install -uy MesaLib-devel libseat-devel eudev-libudev-devel libdrm-devel \
+          xbps-install -y MesaLib-devel libseat-devel eudev-libudev-devel libdrm-devel \
             libinput-devel libxkbcommon-devel pixman-devel wayland-devel wayland-protocols \
             xcb-util-errors-devel xcb-util-wm-devel xcb-util-renderutil-devel libxcb-devel \
             xcb-util-cursor-devel xcb-util-devel xcb-util-image-devel xcb-util-keysyms-devel \


### PR DESCRIPTION
This avoids errors like:

util-linux-common-2.37.2_1 in transaction breaks installed pkg `libfdisk-2.37.1_1'
util-linux-common-2.37.2_1 in transaction breaks installed pkg `libsmartcols-2.37.1_1'
libuuid-2.37.2_1 in transaction breaks installed pkg `libfdisk-2.37.1_1'
libuuid-2.37.2_1 in transaction breaks installed pkg `util-linux-2.37.1_1'
libblkid-2.37.2_1 in transaction breaks installed pkg `libfdisk-2.37.1_1'
libblkid-2.37.2_1 in transaction breaks installed pkg `util-linux-2.37.1_1'
libmount-2.37.2_1 in transaction breaks installed pkg `util-linux-2.37.1_1'
Transaction aborted due to unresolved dependencies.