### PR TITLE
input_method_v2: Use a pointer for keyboard_grab

### DIFF
--- a/src/types/input_method_v2.zig
+++ b/src/types/input_method_v2.zig
@@ -76,7 +76,7 @@ pub const InputMethodV2 = extern struct {
     client_active: bool,
     current_serial: u32,
 
-    keyboard_grab: KeyboardGrab,
+    keyboard_grab: *KeyboardGrab,
 
     link: wl.list.Link,
 


### PR DESCRIPTION
See https://github.com/riverwm/river/pull/405#issuecomment-969214151