### PR TITLE
[Tinywl] allow passing args to build run

### DIFF
--- a/tinywl/build.zig
+++ b/tinywl/build.zig
@@ -52,6 +52,9 @@ pub fn build(b: *Builder) void {
 
     const run_cmd = exe.run();
     run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
 
     const run_step = b.step("run", "Run the compositor");
     run_step.dependOn(&run_cmd.step);


### PR DESCRIPTION
Usage: `zig build run -- foot`