### PR TITLE
bind wlr_server_decoration.h

### DIFF
--- a/src/types/server_decoration.zig
+++ b/src/types/server_decoration.zig
@@ -1,0 +1,52 @@
+const wlr = @import("../wlroots.zig");
+
+const wayland = @import("wayland");
+const wl = wayland.server.wl;
+
+pub const ServerDecorationManager = extern struct {
+    pub const Mode = enum(c_int) {
+        none = 0,
+        client = 1,
+        server = 2,
+    };
+
+    global: *wl.Global,
+    resources: wl.list.Head(wl.Resource, "link"),
+    decorations: wl.list.Head(ServerDecoration, "link"),
+
+    default_mode: Mode,
+
+    server_destroy: wl.Listener(*wl.Server),
+
+    events: extern struct {
+        new_decoration: wl.Signal(*ServerDecoration),
+        destroy: wl.Signal(*ServerDecorationManager),
+    },
+
+    data: usize,
+
+    extern fn wlr_server_decoration_manager_create(server: *wl.Server) ?*ServerDecorationManager;
+    pub fn create(server: *wl.Server) !*ServerDecorationManager {
+        return wlr_server_decoration_manager_create(server) orelse error.OutOfMemory;
+    }
+
+    extern fn wlr_server_decoration_manager_set_default_mode(manager: *ServerDecorationManager, default_mode: Mode) void;
+    pub const setDefaultMode = wlr_server_decoration_manager_set_default_mode;
+};
+
+pub const ServerDecoration = extern struct {
+    resource: *wl.Resource,
+    surface: *wlr.Surface,
+    link: wl.list.Link,
+
+    mode: ServerDecorationManager.Mode,
+
+    events: extern struct {
+        destroy: wl.Signal(*ServerDecoration),
+        mode: wl.Signal(*ServerDecoration),
+    },
+
+    surface_destroy: wl.Listener(*wlr.Surface),
+
+    data: usize,
+};

--- a/src/types/server_decoration.zig
+++ b/src/types/server_decoration.zig
@@ -11,7 +11,7 @@ pub const ServerDecorationManager = extern struct {
     };
 
     global: *wl.Global,
-    resources: wl.list.Head(wl.Resource, "link"),
+    resources: wl.list.Head(wl.Resource, null),
     decorations: wl.list.Head(ServerDecoration, "link"),
 
     default_mode: Mode,

--- a/src/wlroots.zig
+++ b/src/wlroots.zig
@@ -44,6 +44,9 @@ pub const XdgToplevelDecorationV1 = @import("types/xdg_decoration_v1.zig").XdgTo
 pub const XdgActivationV1 = @import("types/xdg_activation_v1.zig").XdgActivationV1;
 pub const XdgActivationTokenV1 = @import("types/xdg_activation_v1.zig").XdgActivationTokenV1;
 
+pub const KdeServerDecorationManager = @import("types/server_decoration.zig").ServerDecorationManager;
+pub const KdeServerDecoration = @import("types/server_decoration.zig").ServerDecoration;
+
 pub const LayerShellV1 = @import("types/layer_shell_v1.zig").LayerShellV1;
 pub const LayerSurfaceV1 = @import("types/layer_shell_v1.zig").LayerSurfaceV1;
 


### PR DESCRIPTION
While `wlr_server_decoration.h` has been [obsolete for 3 years now](https://gitlab.freedesktop.org/wlroots/wlroots/-/blame/master/include/wlr/types/wlr_server_decoration.h#L2), it is still a useful protocol since it is the only decoration protocol that GTK supports at the moment.

I see that river has no plans for supporting this protocol (https://github.com/riverwm/river/issues/24#issuecomment-630100948), however I am making my own compositor using these bindings and would like to support it myself.

An alternative would be that GTK starts supporting the `xdg-decoration` protocol, however it seems the patch for this has not had any activity the last 10 months (https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/2191).

I renamed the `ServerDecoration(Manager)` structs to `KdeServerDecoration(Manager)` in `wlroots.zig` since I found the former to be too general of a name.