### PR TITLE
tablet_tool: fix Tip State enum values

### DIFF
--- a/src/types/tablet_tool.zig
+++ b/src/types/tablet_tool.zig
@@ -74,8 +74,8 @@ pub const Tablet = extern struct {
 
         pub const Tip = extern struct {
             pub const State = enum(c_int) {
-                up,
-                down,
+                up = 1 << 0,
+                down = 1 << 1,
             };
 
             device: *wlr.InputDevice,


### PR DESCRIPTION
https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/master/include/wlr/types/wlr_tablet_tool.h#L125