### PR TITLE
input_method_v2: PreeditString text and State commit_text can be null

### DIFF
--- a/src/types/input_method_v2.zig
+++ b/src/types/input_method_v2.zig
@@ -22,7 +22,7 @@ pub const InputMethodManagerV2 = extern struct {
 
 pub const InputMethodV2 = extern struct {
     pub const PreeditString = extern struct {
-        text: [*:0]u8,
+        text: ?[*:0]u8,
         cursor_begin: i32,
         cursor_end: i32,
     };
@@ -34,7 +34,7 @@ pub const InputMethodV2 = extern struct {
 
     pub const State = extern struct {
         preedit: wlr.InputMethodV2.PreeditString,
-        commit_text: [*:0]u8,
+        commit_text: ?[*:0]u8,
         delete: wlr.InputMethodV2.DeleteSurroundingText,
     };
 


### PR DESCRIPTION
Notably, these strings can be null if the IME hasn't sent `commit_string` or `set_preedit_string` before sending `done`, as the pending state is initialized to zero each time.