### PR TITLE
Fix wlr.Output make, model, serial fields

### DIFF
--- a/src/types/output.zig
+++ b/src/types/output.zig
@@ -166,9 +166,9 @@ pub const Output = extern struct {
 
     name: [*:0]u8,
     description: ?[*:0]u8,
-    make: ?*[*:0]u8,
-    model: ?*[*:0]u8,
-    serial: ?*[*:0]u8,
+    make: ?[*:0]u8,
+    model: ?[*:0]u8,
+    serial: ?[*:0]u8,
     phys_width: i32,
     phys_height: i32,
 


### PR DESCRIPTION
In the `wlr/types/wlr_output.h`, `wlr_output`'s `make`, `model`, and `serial` fields are all defined as `char *` that may be `NULL`, but currently in these bindings, they're defined as a nullable pointer to a C string (`?*[*:0]u8`), which is incorrect.
This MR makes these fields into nullable C strings (`?[*:0]u8`).