### PR TITLE
fix(SceneNode): Parent type should be SceneTree

### DIFF
--- a/src/types/scene.zig
+++ b/src/types/scene.zig
@@ -16,7 +16,7 @@ pub const SceneNode = extern struct {
     };
 
     type: Type,
-    parent: ?*SceneNode,
+    parent: ?*SceneTree,
 
     link: wl.list.Link,
 

--- a/tinywl/tinywl.zig
+++ b/tinywl/tinywl.zig
@@ -206,9 +206,9 @@ const Server = struct {
             const scene_buffer = wlr.SceneBuffer.fromNode(node);
             const scene_surface = wlr.SceneSurface.fromBuffer(scene_buffer) orelse return null;
 
-            var it: ?*wlr.SceneNode = node;
-            while (it) |n| : (it = n.parent) {
-                if (@as(?*View, @ptrFromInt(n.data))) |view| {
+            var it: ?*wlr.SceneTree = node.parent;
+            while (it) |n| : (it = n.node.parent) {
+                if (@as(?*View, @ptrFromInt(n.node.data))) |view| {
                     return ViewAtResult{
                         .view = view,
                         .surface = scene_surface.surface,


### PR DESCRIPTION
* Parent type was incorrectly bound to `?*SceneNode` when it should really be `?*SceneTree`.

* Closes: https://github.com/swaywm/zig-wlroots/issues/67

* Ref: https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/1712a7d27444d62f8da8eeedf0840b386a810e96/include/wlr/types/wlr_scene.h#L50

* Ref commit: https://github.com/wlrfx/zig-wlroots/commit/e6d90599421e5e024ff4496b9ae79163b6c6e338