### PR TITLE
gitmodules: fix codeberg url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://codeberg.org/ifreund/zig-wayland
 [submodule "tinywl/deps/zig-xkbcommon"]
 	path = tinywl/deps/zig-xkbcommon
-	url = https://codeberg/ifreund/zig-xkbcommon
+	url = https://codeberg.org/ifreund/zig-xkbcommon
 [submodule "tinywl/deps/zig-pixman"]
 	path = tinywl/deps/zig-pixman
 	url = https://codeberg.org/ifreund/zig-pixman


### PR DESCRIPTION
Encountered git submodule clone failures while building river. Thought I'd just quickly fix this :)